### PR TITLE
Changing the way of fetching scene elements

### DIFF
--- a/samples/extensions/extended_dynamic_state2/extended_dynamic_state2.cpp
+++ b/samples/extensions/extended_dynamic_state2/extended_dynamic_state2.cpp
@@ -95,14 +95,14 @@ void ExtendedDynamicState2::load_assets()
 	load_scene("scenes/primitives/primitives.gltf");
 
 	std::vector<SceneNode>       scene_elements;
-	std::vector<vkb::sg::Node *> node_scene_list = scene->get_root_node().get_children();
+	std::vector<vkb::sg::Node *> node_scene_list = { &(scene->get_root_node()) };
 	vkb::sg::Node *              node            = nullptr;
 
 	for (size_t list_it = 0; node_scene_list.size() > list_it; ++list_it)
 	{
 		node = node_scene_list[list_it];
 
-		// Add node childs to vector if they exist
+		// Add node children to vector if they exist
 		if (!node->get_children().empty())
 		{
 			node_scene_list.insert(

--- a/samples/extensions/extended_dynamic_state2/extended_dynamic_state2.cpp
+++ b/samples/extensions/extended_dynamic_state2/extended_dynamic_state2.cpp
@@ -98,9 +98,9 @@ void ExtendedDynamicState2::load_assets()
 	std::vector<vkb::sg::Node *> node_scene_list = scene->get_root_node().get_children();
 	vkb::sg::Node *              node            = nullptr;
 
-	for (size_t list_it = 0; node_scene_list.size() > list_it; list_it++)
+	for (size_t list_it = 0; node_scene_list.size() > list_it; ++list_it)
 	{
-		node = node_scene_list.at(list_it);
+		node = node_scene_list[list_it];
 
 		// Add node childs to vector if they exist
 		if (!node->get_children().empty())

--- a/samples/extensions/extended_dynamic_state2/extended_dynamic_state2.cpp
+++ b/samples/extensions/extended_dynamic_state2/extended_dynamic_state2.cpp
@@ -94,17 +94,34 @@ void ExtendedDynamicState2::load_assets()
 {
 	load_scene("scenes/primitives/primitives.gltf");
 
-	std::vector<SceneNode> scene_elements;
-	// Store all scene nodes in a linear vector for easier access
-	for (auto &mesh : scene->get_components<vkb::sg::Mesh>())
+	std::vector<SceneNode>       scene_elements;
+	std::vector<vkb::sg::Node *> node_scene_list = scene->get_root_node().get_children();
+	vkb::sg::Node *              node            = nullptr;
+
+	for (size_t list_it = 0; node_scene_list.size() > list_it; list_it++)
 	{
-		for (auto &node : mesh->get_nodes())
+		node = node_scene_list.at(list_it);
+
+		// Add node childs to vector if they exist
+		if (!node->get_children().empty())
 		{
+			node_scene_list.insert(
+			                        node_scene_list.end(),
+			                        node->get_children().begin(),
+			                        node->get_children().end());
+		}
+
+		// If current node have mesh add it to scene_elements
+		if (node->has_component<vkb::sg::Mesh>())
+		{
+			vkb::sg::Mesh &mesh = node->get_component<vkb::sg::Mesh>();
+
 			ModelDynamicParam object_param{};
 			gui_settings.objects.push_back(object_param);
-			for (auto &sub_mesh : mesh->get_submeshes())
+
+			for (auto &sub_mesh : mesh.get_submeshes())
 			{
-				scene_elements.push_back({mesh->get_name(), node, sub_mesh});
+				scene_elements.push_back({mesh.get_name(), node, sub_mesh});
 			}
 		}
 	}


### PR DESCRIPTION
Scene elements are fetched as they traverse the scene tree

## Description

Please include a summary of the change, new sample or fixed issue. Please also include relevant motivation and context.
Please read the [contribution guidelines](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md)

Fixes #<issue number>

## General Checklist:

Please ensure the following points are checked:

- [ ] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [ ] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [ ] I have updated the header Copyright to reflect the current year (CI build will fail if Copyright is out of date)
- [ ] I have commented any added functions (in line with Doxygen)
- [ ] I have commented any code that could be hard to understand
- [ ] My changes do not add any new compiler warnings
- [ ] My changes do not add any new validation layer errors or warnings
- [ ] I have used existing framework/helper functions where possible
- [ ] My changes build on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [ ] My changes do not add any regressions
- [ ] I have tested every sample to ensure everything runs correctly
- [ ] This PR describes the scope and expected impact of the changes I am making

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [ ] I have tested the sample on at least one compliant Vulkan implementation
- [ ] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [ ] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ ] Any dependent assets have been merged and published in downstream modules
- [ ] For new samples, I have added a paragraph with a summary to the appropriate chapter in the [samples readme](./../samples/README.md)
